### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "@azure/keyvault-secrets": "^4.7.0",
     "express": "^4.18.2",
     "mssql": "^10.0.1",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "express-rate-limit": "^8.2.1"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch');
 const { DefaultAzureCredential } = require('@azure/identity');
 const { SecretClient } = require('@azure/keyvault-secrets');
 const sql = require('mssql');
+const rateLimit = require('express-rate-limit');
 
 const osMapping = {
     "Windows 11": {
@@ -35,6 +36,11 @@ const app = express();
 const port = 3001;
 app.use(express.json());
 
+const provisionVmLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
 // Azure Key Vault details
 const credential = new DefaultAzureCredential();
 const vaultName = process.env["KEY_VAULT_NAME"];
@@ -66,7 +72,7 @@ async function getSqlConfig() {
     };
 }
 
-app.post('/provision-vm', async (req, res) => {
+app.post('/provision-vm', provisionVmLimiter, async (req, res) => {
     try {
         const vmConfig = processVmConfig(req.body);
 


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/react-vm-provisioning/security/code-scanning/1](https://github.com/passadis/react-vm-provisioning/security/code-scanning/1)

In general, to fix missing rate limiting for an Express route that performs expensive operations, you should add a rate-limiting middleware (such as `express-rate-limit`) and apply it either globally or to the specific sensitive routes. This limits how many requests a client (typically by IP) can make within a time window, reducing the risk of denial-of-service attacks targeting database, filesystem, or external service calls.

For this specific code, the least invasive, functionality-preserving fix is to import and configure `express-rate-limit` once in `backend/server.js`, then apply the resulting limiter middleware only to the `/provision-vm` route. That way, other routes (if any) remain unaffected, while the DB-intensive endpoint gains protection. Concretely:
- Add `const rateLimit = require('express-rate-limit');` near the other `require` statements at the top of `backend/server.js`.
- After creating `app` and before defining the `/provision-vm` route, define a limiter, e.g.:
  - `windowMs`: 15 * 60 * 1000 (15 minutes)
  - `max`: some sensible cap like 100 requests per window per IP (or stricter if desired).
- Change the route definition from `app.post('/provision-vm', async (req, res) => { ... })` to `app.post('/provision-vm', provisionVmLimiter, async (req, res) => { ... })`, where `provisionVmLimiter` is the configured rate-limiter instance.

This keeps the existing behavior of the handler (same request body, same DB operations, same responses) but ensures that excessive requests from the same client will receive HTTP 429 responses instead of triggering repeated DB operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
